### PR TITLE
Fix Frends.Tasks.Attributes reference to a working version (1.2.1)

### DIFF
--- a/Frends.Json/Frends.Json.csproj
+++ b/Frends.Json/Frends.Json.csproj
@@ -33,8 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Frends.Tasks.Attributes, Version=1.2.0.0, Culture=neutral, PublicKeyToken=258fd606323928fc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Frends.Tasks.Attributes.1.2.0\lib\net40\Frends.Tasks.Attributes.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Frends.Tasks.Attributes.1.2.1\lib\net40\Frends.Tasks.Attributes.dll</HintPath>
     </Reference>
     <Reference Include="Handlebars, Version=1.0.0.0, Culture=neutral, PublicKeyToken=22225d0bf33cd661, processorArchitecture=MSIL">
       <HintPath>..\packages\Handlebars.Net.1.7.1\lib\Handlebars.dll</HintPath>

--- a/Frends.Json/packages.config
+++ b/Frends.Json/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Frends.Tasks.Attributes" version="1.2.0" targetFramework="net452" />
+  <package id="Frends.Tasks.Attributes" version="1.2.1" targetFramework="net452" />
   <package id="Handlebars.Net" version="1.7.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
   <package id="Newtonsoft.Json.Schema" version="1.0.11" targetFramework="net452" />

--- a/README.md
+++ b/README.md
@@ -3,26 +3,12 @@
    - [Building](#building)
    - [Contributing](#contributing)
    - [Documentation](#documentation)
-     - [Json.Query](#json.query)
-       - [Input](#input)
-       - [Options](#options)
-       - [Result](#result)
-     - [Json.QuerySingle](#json.querysingle)
-       - [Input](#input)
-       - [Options](#options)
-       - [Result](#result)
-     - [Json.Handlebars](#json.handlebars)
-       - [Input](#input)
-       - [Result](#result)
-     - [Json.Validate](#json.validate)
-       - [Input](#input)
-       - [Result](#result)
-     - [Json.ConvertXmlStringToJToken](#json.convertxmlstringtojtoken)
-       - [Input](#input)
-       - [Result](#result)
-     - [Json.ConvertJsonStringToJToken](#json.convertjsonstringtojtoken)
-       - [Input](#input)
-       - [Result](#result)
+     - [Json.Query](#jsonquery) 
+     - [Json.QuerySingle](#jsonquerysingle)
+     - [Json.Handlebars](#jsonhandlebars)
+     - [Json.Validate](#jsonvalidate)
+     - [Json.ConvertXmlStringToJToken](#jsonconvertxmlstringtojtoken)
+     - [Json.ConvertJsonStringToJToken](#jsonconvertjsonstringtojtoken)
    - [License](#license)
 
 # Frends.Json
@@ -32,7 +18,6 @@ You can install the task via FRENDS UI Task View or you can find the nuget packa
 `https://www.myget.org/F/frends/api/v2`
 
 ## Building
-Ensure that you have `https://www.myget.org/F/frends/api/v2` added to your nuget feeds
 
 Clone a copy of the repo
 

--- a/nuspec/Frends.Json.nuspec
+++ b/nuspec/Frends.Json.nuspec
@@ -10,7 +10,6 @@
     <description>FRENDS Json tasks</description>
     <summary />
     <dependencies>
-	    <dependency id="Frends.Tasks.Attributes" version="1.2.0" />
       <dependency id="Newtonsoft.Json" version="6.0.8" />
       <dependency id="Newtonsoft.Json.Schema" version="2.0.8" />
       <dependency id="Handlebars.Net" version="[1.7.1]" />
@@ -21,7 +20,7 @@
     </frameworkAssemblies>
   </metadata>
   <files>
-	<file src="Frends.Json\bin\Release\Frends.Json.dll" target="lib\net452\Frends.Json.dll" />	
+	<file src="Frends.Json\bin\Release\Frends.Json.dll" target="lib\net452\Frends.Json.dll" />
     <file src="Frends.Json\bin\Release\Frends.Json.XML" target="Frends.Json.XML"/>
     <file src="Frends.Json\FrendsTaskMetadata.json" target="FrendsTaskMetadata.json"/>
   </files>


### PR DESCRIPTION
Version 1.2.0 cannot be used as it has the wrong assembly version, so compilation will fail.