### PR TITLE
Replaced Frends.tasks.attributes with System.ComponentModel.DataAnnotations

### DIFF
--- a/Frends.Json/Definitions.cs
+++ b/Frends.Json/Definitions.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using Frends.Tasks.Attributes;
+using System.ComponentModel.DataAnnotations;
+
 #pragma warning disable 1591
 
 namespace Frends.Json
@@ -12,7 +13,7 @@ namespace Frends.Json
         /// Json input needs to be of type string or JToken
         /// </summary>
         [DefaultValue("{\"key\":\"value\"}")]
-        [DefaultDisplayType(DisplayType.Json)]
+        [DisplayFormat(DataFormatString = "Json")]
         public dynamic Json { get; set; }
 
         /// <summary>
@@ -36,18 +37,18 @@ namespace Frends.Json
         /// Json input needs to be of type string or JToken
         /// </summary>
         [DefaultValue("{\"title\":\"Mr.\", \"name\":\"Foo\" }")]
-        [DefaultDisplayType(DisplayType.Json)]
+        [DisplayFormat(DataFormatString = "Json")]
         public dynamic Json { get; set; }
 
         /// <summary>
         /// Template for handlebars. > indicates a partial. This needs to be in expression mode. Using {{ }} in other modes breaks the task.
         /// </summary>
         [DefaultValue("\"<xml> {{title}} {{> strongName}} </xml>\"")]
-        [DefaultDisplayType(DisplayType.Expression)]
+        [DisplayFormat(DataFormatString = "Expression")]
         public string HandlebarTemplate { get; set; }
 
         /// <summary>
-        /// Partials for template. 
+        /// Partials for template.
         /// </summary>
         public HandlebarPartial[] HandlebarPartials { get; set; }
     }
@@ -64,7 +65,7 @@ namespace Frends.Json
         /// Partial template. This needs to be in expression mode. Using {{ }} in other modes breaks the task.
         /// </summary>
         [DefaultValue("\"<strong>{{name}}</strong>\"")]
-        [DefaultDisplayType(DisplayType.Expression)]
+        [DisplayFormat(DataFormatString = "Expression")]
         public string Template { get; set; }
     }
 
@@ -74,20 +75,20 @@ namespace Frends.Json
         /// Json input needs to be of type string or JToken
         /// </summary>
         [DefaultValue("{\"name\": \"Foo\"}")]
-        [DefaultDisplayType(DisplayType.Json)]
+        [DisplayFormat(DataFormatString = "Json")]
         public dynamic Json { get; set; }
 
         /// <summary>
         /// Json Schema to validate to. Uses Newtonsoft JsonSchema
         /// </summary>
         [DefaultValue("{\"type\": \"object\", \"properties\": {\"name\": {\"type\":\"string\"} } }")]
-        [DefaultDisplayType(DisplayType.Json)]
+        [DisplayFormat(DataFormatString = "Json")]
         public string JsonSchema { get; set; }
     }
 
     public class ValidateOption
     {
-        public bool ThrowOnInvalidJson { get; set; }        
+        public bool ThrowOnInvalidJson { get; set; }
     }
 
     public class ValidateResult

--- a/Frends.Json/Frends.Json.csproj
+++ b/Frends.Json/Frends.Json.csproj
@@ -32,9 +32,6 @@
     <DocumentationFile>bin\Release\Frends.Json.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Frends.Tasks.Attributes, Version=1.2.0.0, Culture=neutral, PublicKeyToken=258fd606323928fc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Frends.Tasks.Attributes.1.2.1\lib\net40\Frends.Tasks.Attributes.dll</HintPath>
-    </Reference>
     <Reference Include="Handlebars, Version=1.0.0.0, Culture=neutral, PublicKeyToken=22225d0bf33cd661, processorArchitecture=MSIL">
       <HintPath>..\packages\Handlebars.Net.1.7.1\lib\Handlebars.dll</HintPath>
       <Private>True</Private>
@@ -48,6 +45,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Numerics" />
@@ -64,7 +62,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Frends.Json/Json.cs
+++ b/Frends.Json/Json.cs
@@ -1,5 +1,5 @@
-﻿using Frends.Tasks.Attributes;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Xml;
@@ -10,17 +10,16 @@ using Newtonsoft.Json.Schema;
 
 namespace Frends.Json
 {
-   
     public class Json
     {
         /// <summary>
         /// Query a json string / json token for a single result. See https://github.com/FrendsPlatform/Frends.Json
         /// </summary>
         /// <returns>JToken</returns>
-        public static object QuerySingle([CustomDisplay(DisplayOption.Tab)] QueryInput input, [CustomDisplay(DisplayOption.Tab)] QueryOptions options)
+        public static object QuerySingle([PropertyTab] QueryInput input, [PropertyTab] QueryOptions options)
         {
             JToken jToken = GetJTokenFromInput(input.Json);
-           
+
             return jToken.SelectToken(input.Query,options.ErrorWhenNotMatched);
         }
 
@@ -28,7 +27,7 @@ namespace Frends.Json
         /// Query a json string / json token. See https://github.com/FrendsPlatform/Frends.Json
         /// </summary>
         /// <returns>JToken[]</returns>
-        public static IEnumerable<object> Query([CustomDisplay(DisplayOption.Tab)] QueryInput input, [CustomDisplay(DisplayOption.Tab)] QueryOptions options)
+        public static IEnumerable<object> Query([PropertyTab] QueryInput input, [PropertyTab] QueryOptions options)
         {
             JToken jToken = GetJTokenFromInput(input.Json);
 
@@ -60,7 +59,7 @@ namespace Frends.Json
         /// Validate your json with Json.NET Schema. See http://www.newtonsoft.com/jsonschema and https://github.com/FrendsPlatform/Frends.Json
         /// </summary>
         /// <returns>Object { bool IsValid, string Error }</returns>
-        public static ValidateResult Validate([CustomDisplay(DisplayOption.Tab)]ValidateInput input, [CustomDisplay(DisplayOption.Tab)] ValidateOption options)
+        public static ValidateResult Validate([PropertyTab]ValidateInput input, [PropertyTab] ValidateOption options)
         {
             var schema = JSchema.Parse(input.JsonSchema);
             JToken jToken = GetJTokenFromInput(input.Json);

--- a/Frends.Json/packages.config
+++ b/Frends.Json/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Frends.Tasks.Attributes" version="1.2.1" targetFramework="net452" />
   <package id="Handlebars.Net" version="1.7.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
   <package id="Newtonsoft.Json.Schema" version="1.0.11" targetFramework="net452" />


### PR DESCRIPTION
Replaced usage of custom attributes from Frends.tasks.attributes with their counterparts from System.ComponentModel.DataAnnotations, as the Frends.Tasks.Attributes reference mostly does not work